### PR TITLE
Default protocol behavior

### DIFF
--- a/proxy-out.js
+++ b/proxy-out.js
@@ -65,9 +65,10 @@ http.request = function(options, callback) {
     options = _parseOptions(options);
   }
 
-  // If there is no supplied protocol, assume a URI option is being passed
+  // If there is no supplied protocol, pull from uri or default to 'http:'
   if(!options.protocol) {
     _.extend(options, options.uri);
+    options.protocol = options.protocol || 'http:';
   }
 
   if(_whitelist.indexOf(options.hostname) < 0) {
@@ -95,9 +96,10 @@ https.request = function(options, callback) {
     options = _parseOptions(options);
   }
 
-  // If there is no supplied protocol, assume a URI option is being passed
+  // If there is no supplied protocol, pull from uri or default to 'https:'
   if(!options.protocol) {
     _.extend(options, options.uri);
+    options.protocol = options.protocol || 'https:';
   }
 
   if(_whitelist.indexOf(options.hostname) < 0) {

--- a/test.js
+++ b/test.js
@@ -1,5 +1,6 @@
 var url = require('url');
 var http = require('http');
+var https = require('https');
 var mocha = require('mocha');
 var expect = require('chai').expect;
 
@@ -37,6 +38,30 @@ describe('proxy-out', function() {
         path: ''
       }, function(res) {
         expect(successCodes).to.include(res.statusCode);
+        done();
+      });
+    });
+
+    it('should infer protocol properly for http', function(done) {
+      require('./proxy-out')(proxyUrl);
+      http.get({
+        host: 'google.com',
+        path: ''
+      }, function(res) {
+        expect(successCodes).to.include(res.statusCode);
+        expect(res.headers.location).to.eq('http://www.google.com/');
+        done();
+      });
+    });
+
+    it('should infer protocol properly for https', function(done) {
+      require('./proxy-out')(proxyUrl);
+      https.get({
+        host: 'google.com',
+        path: ''
+      }, function(res) {
+        expect(successCodes).to.include(res.statusCode);
+        expect(res.headers.location).to.eq('https://www.google.com/');
         done();
       });
     });


### PR DESCRIPTION
At least some calls into request (e.g. from superagent) do not pass on protocol explicitly, but it can be inferred by whether the object the request is being called on.
