### PR TITLE
Changing proxy method

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "contributors": [
     {
-      "name": "James J. Womack"
+      "name": "James J. Womack",
+      "name": "Alan Cruz"
     }
   ],
   "license": "MIT",
@@ -24,7 +25,8 @@
   },
   "homepage": "https://github.com/ryan-rowland/proxy-out",
   "dependencies": {
-    "tunnel": "0.0.3",
+    "http-proxy-agent": "^1.0.0",
+    "https-proxy-agent": "^1.0.0",
     "underscore": "^1.7.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,8 +1,9 @@
 {
   "name": "proxy-out",
-  "version": "0.0.13",
+  "version": "0.0.14",
   "description": "Override HTTP and HTTPS to set global proxy out settings",
   "main": "proxy-out.js",
+  "engines": { "node" : ">=4.0.0"},
   "scripts": {
     "test": "mocha --ui bdd -R spec test.js"
   },
@@ -37,7 +38,7 @@
   "_id": "proxy-out@0.0.9",
   "_shasum": "599b3646f9e5f4c57952822861327b1ade6632ae",
   "_from": "proxy-out@0.0.9",
-  "_npmVersion": "1.4.16",
+  "_npmVersion": "2.15.8",
   "_npmUser": {
     "name": "ryanrowland",
     "email": "ryan.w.rowland@gmail.com"

--- a/test.js
+++ b/test.js
@@ -35,7 +35,7 @@ describe('proxy-out', function() {
       http.get({
         protocol: 'http:',
         host: 'google.com:80',
-        path: ''
+        path: '/'
       }, function(res) {
         expect(successCodes).to.include(res.statusCode);
         done();
@@ -111,4 +111,5 @@ describe('proxy-out', function() {
     });
   });
 });
+
 


### PR DESCRIPTION
Hey Ryan,

The HTTP/HTTPS request methods changed in node v4 and higher, causing the previous proxy to no longer work. We pulled in other proxy libraries to handle any additional changes to the request method and utilize that as the outgoing proxy.

We tested the compatibility with node 0.10 and did not see any issues.